### PR TITLE
adding a link to the contribution doc on the main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Available under [docs](/docs).
 ## Examples
 
 Available under [examples](/examples).
+
+## Contributing
+
+Please see [CONTRIBUTING.md](/.github/contributing.md) for details on how to help grow this repository.


### PR DESCRIPTION
I hope the relative link works on GitHub, but I've never tried linking to `.github/` before.