### PR TITLE
Only publish results if not Dependabot

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,6 +2,9 @@ name: cypress tests
 
 on: [pull_request]
 
+permissions:
+  actions: write
+
 jobs:
   build:
     name: Building site and running cypress tests
@@ -19,7 +22,7 @@ jobs:
 
       - name: Publish test results.
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: github.actor != 'dependabot[bot]'
+        if: always()
         with:
           files: cypress/*.xml
           check_name: "Cypress Test Results"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,7 @@ name: cypress tests
 on: [pull_request]
 
 permissions:
-  actions: write
+  actions: all
 
 jobs:
   build:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,9 +2,6 @@ name: cypress tests
 
 on: [pull_request]
 
-permissions:
-  actions: all
-
 jobs:
   build:
     name: Building site and running cypress tests
@@ -22,7 +19,7 @@ jobs:
 
       - name: Publish test results.
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
+        if: github.actor != 'dependabot[bot]'
         with:
           files: cypress/*.xml
           check_name: "Cypress Test Results"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Publish test results.
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
+        if: github.actor != 'dependabot[bot]'
         with:
           files: cypress/*.xml
           check_name: "Cypress Test Results"


### PR DESCRIPTION
I think the PR test runs for Dependabot updates fail since it doesn't have permission to upload the results...we'll see if "Archive test results" passes, but I would think that step should have the same issue.

Based off of this failure: https://github.com/CivicActions/cypress-tests/actions/runs/3840818035/jobs/6540322222#step:6:29