### PR TITLE
Updating links to tagging article

### DIFF
--- a/utilities/README.md
+++ b/utilities/README.md
@@ -4,6 +4,6 @@ Contains JavaScript files with examples of useful utility functions.
 
 ## Useful references
 
-- Cucumber-like tag filter based on https://www.mariedrake.com/post/using-tags-to-filter-your-cypress-tests.
+- Cucumber-like tag filter based on https://www.testingwithmarie.com/post/using-tags-to-filter-your-cypress-tests.
 - https://medium.com/appear-here-product-engineering/testing-iframes-with-cypress-including-stripe-and-hellosign-fed90d639870
 - Cypress cookies https://docs.cypress.io/api/cypress-api/cookies#Preserve-Function

--- a/utilities/tags.js
+++ b/utilities/tags.js
@@ -1,5 +1,5 @@
 /*
- * Cucumber-like tag filter based on https://www.mariedrake.com/post/using-tags-to-filter-your-cypress-tests.
+ * Cucumber-like tag filter based on https://www.testingwithmarie.com/post/using-tags-to-filter-your-cypress-tests.
  */
 
 let tags = (definedTags) => {


### PR DESCRIPTION
The old link is going to a sketchy place so apologizes for that.