### PR TITLE
Removing uncaught exception handling for CKEditor example tests

### DIFF
--- a/cypress/e2e/3-civicactions-examples/drupal-ckeditor.cy.js
+++ b/cypress/e2e/3-civicactions-examples/drupal-ckeditor.cy.js
@@ -4,15 +4,9 @@ import 'cypress-file-upload'
 
 // In a newer version of Drupal we are getting this error, so ignoring it for now.
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
-// Drupal issue https://www.drupal.org/project/drupal/issues/3413079.
-const nodeTypePropertiesError =
-  /^[^(TypeError: Cannot read properties of null (reading 'nodeType'))]/
 Cypress.on('uncaught:exception', (err) => {
   /* returning false here prevents Cypress from failing the test */
   if (resizeObserverLoopErrRe.test(err.message)) {
-    return false
-  }
-  if (nodeTypePropertiesError.test(err.message)) {
     return false
   }
 })


### PR DESCRIPTION
# 📝 One-line Summary

The uncaught exception handling was added because of Drupal core JS issues causing Cypress test failures. Since it is fixed it can be removed.

