### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,6 +2,9 @@ name: cypress tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Building site and running cypress tests

--- a/cypress/e2e/3-civicactions-examples/a11y.cy.js
+++ b/cypress/e2e/3-civicactions-examples/a11y.cy.js
@@ -115,9 +115,7 @@ context('CA a11y site accessibility', () => {
               (() => {
                 const parsedUrl = url.parse(page[0])
                 const host = parsedUrl.host
-                const allowedHosts = [
-                  'accessibility.civicactions.com',
-                ]
+                const allowedHosts = ['accessibility.civicactions.com']
                 return allowedHosts.includes(host)
               })() &&
               path.extname(page[0]) !== '.pdf'

--- a/cypress/e2e/3-civicactions-examples/a11y.cy.js
+++ b/cypress/e2e/3-civicactions-examples/a11y.cy.js
@@ -113,13 +113,13 @@ context('CA a11y site accessibility', () => {
             if (
               withinTimeframe &&
               (() => {
-                const parsedUrl = url.parse(page[0]);
-                const host = parsedUrl.host;
+                const parsedUrl = url.parse(page[0])
+                const host = parsedUrl.host
                 const allowedHosts = [
                   'accessibility.civicactions.com',
-                  'www.accessibility.civicactions.com'
-                ];
-                return allowedHosts.includes(host);
+                  'www.accessibility.civicactions.com',
+                ]
+                return allowedHosts.includes(host)
               })() &&
               path.extname(page[0]) !== '.pdf'
             ) {

--- a/cypress/e2e/3-civicactions-examples/a11y.cy.js
+++ b/cypress/e2e/3-civicactions-examples/a11y.cy.js
@@ -4,6 +4,7 @@ import 'x2js'
 
 const X2JS = require('x2js')
 const path = require('path')
+const url = require('url')
 
 context('CA home site accessibility', () => {
   const casite = 'https://civicactions.com/'
@@ -111,7 +112,15 @@ context('CA a11y site accessibility', () => {
             // Ensure the page has been changed in the timeframe and the pages are not external or PDFs.
             if (
               withinTimeframe &&
-              page[0].includes(a11ysite) &&
+              (() => {
+                const parsedUrl = url.parse(page[0]);
+                const host = parsedUrl.host;
+                const allowedHosts = [
+                  'accessibility.civicactions.com',
+                  'www.accessibility.civicactions.com'
+                ];
+                return allowedHosts.includes(host);
+              })() &&
               path.extname(page[0]) !== '.pdf'
             ) {
               cy.visit(page[0], { failOnStatusCode: false })

--- a/cypress/e2e/3-civicactions-examples/a11y.cy.js
+++ b/cypress/e2e/3-civicactions-examples/a11y.cy.js
@@ -117,7 +117,6 @@ context('CA a11y site accessibility', () => {
                 const host = parsedUrl.host
                 const allowedHosts = [
                   'accessibility.civicactions.com',
-                  'www.accessibility.civicactions.com',
                 ]
                 return allowedHosts.includes(host)
               })() &&


### PR DESCRIPTION
Potential fix for [https://github.com/CivicActions/cypress-tests/security/code-scanning/1](https://github.com/CivicActions/cypress-tests/security/code-scanning/1)

To fix the problem, we need to parse the URL and check its host against a whitelist of allowed hosts. This ensures that the URL belongs to a trusted domain and is not a maliciously crafted URL. We will use the `url` module to parse the URL and extract the host for comparison.

1. Import the `url` module.
2. Parse the URL to extract the host.
3. Compare the host against a whitelist of allowed hosts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
